### PR TITLE
[#169] parse_pg_output 파싱 실패시 루프를 중단하게 변경

### DIFF
--- a/src/pipes/postgres.rs
+++ b/src/pipes/postgres.rs
@@ -297,10 +297,20 @@ impl IPipe for PostgresPipe {
 
             // 2. Parse peeked rows, group by table and prepare for insert/update/delete
             for row in peek_result.iter() {
-                let Some(parsed_row) =
-                    parse_pg_output(&row.data).expect("Failed to parse PgOutput")
-                else {
-                    continue;
+                let parsed_row = match parse_pg_output(&row.data) {
+                    Ok(Some(parsed)) => parsed,
+                    Ok(None) => continue,
+                    Err(e) => {
+                        log::error!(
+                            "Failed to parse PgOutput: {e:?}. Raw data (hex): {}",
+                            row.data
+                                .iter()
+                                .map(|b| format!("{b:02x}"))
+                                .collect::<Vec<_>>()
+                                .join(" ")
+                        );
+                        panic!("Aborting due to PgOutput parse failure");
+                    }
                 };
 
                 let Some(PostgresTableRelation {


### PR DESCRIPTION
resolved: #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 데이터 처리 중 오류 발생 시 더 상세한 로깅 정보를 추가하여 문제 진단을 개선했습니다. 에러 메시지가 명확해지고 디버깅이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->