### PR TITLE
[#168] fix: 동일 peek 내 중복 행을 마지막 값 기준으로 dedup하여 INSERT/UPDATE 유실 방지

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -2,6 +2,8 @@ pub mod clickhouse;
 pub mod mongodb;
 pub mod postgres;
 
+use std::collections::HashSet;
+
 use crate::{
     adapter::clickhouse::{ClickhouseColumn, ClickhouseType},
     config::{
@@ -251,4 +253,17 @@ pub trait IntoClickhouse {
 
         delete_query
     }
+}
+
+/// Deduplicates rows by a key derived from each row, keeping the last occurrence per key.
+/// The relative order of first-seen keys is preserved.
+pub fn deduplicate_rows_keeping_last<T>(rows: Vec<T>, key_fn: impl Fn(&T) -> String) -> Vec<T> {
+    let mut seen = HashSet::new();
+    let mut result: Vec<T> = rows
+        .into_iter()
+        .rev()
+        .filter(|row| seen.insert(key_fn(row)))
+        .collect();
+    result.reverse();
+    result
 }

--- a/src/pipes/mongodb.rs
+++ b/src/pipes/mongodb.rs
@@ -422,7 +422,7 @@ impl IPipe for MongoDBPipe {
                     &Vec::<MongoDBColumn>::new(), // MongoDB does not have a fixed schema, so we pass an empty slice here
                     &batch.mask_columns,
                     table_name,
-                    &batch.rows,
+                    &batch.deduplicated_rows(),
                 );
 
                 if !insert_query.is_empty() {
@@ -681,4 +681,16 @@ impl BatchWriteEntry<'_> {
     pub fn push(&mut self, row: MongoDBCopyRow) {
         self.rows.push(row);
     }
+
+    pub fn deduplicated_rows(&self) -> Vec<MongoDBCopyRow> {
+        adapter::deduplicate_rows_keeping_last(self.rows.clone(), extract_mongodb_primary_key)
+    }
+}
+
+fn extract_mongodb_primary_key(row: &MongoDBCopyRow) -> String {
+    row.columns
+        .iter()
+        .find(|col| col.column_name == "_id")
+        .map(|col| format!("{:?}", col.bson_value))
+        .unwrap_or_default()
 }

--- a/src/pipes/postgres.rs
+++ b/src/pipes/postgres.rs
@@ -427,7 +427,7 @@ impl IPipe for PostgresPipe {
                     &batch.table_info.postgres_columns,
                     &batch.mask_columns,
                     table_name,
-                    &batch.rows,
+                    &batch.deduplicated_rows(),
                 );
 
                 if !insert_query.is_empty() {
@@ -778,4 +778,25 @@ impl BatchWriteEntry<'_> {
     pub fn push(&mut self, row: PostgresCopyRow) {
         self.rows.push(row);
     }
+
+    pub fn deduplicated_rows(&self) -> Vec<PostgresCopyRow> {
+        adapter::deduplicate_rows_keeping_last(self.rows.clone(), |row| {
+            extract_postgres_primary_key(row, &self.table_info.postgres_columns)
+        })
+    }
+}
+
+fn extract_postgres_primary_key(row: &PostgresCopyRow, columns: &[PostgresColumn]) -> String {
+    columns
+        .iter()
+        .filter(|col| col.is_primary_key)
+        .map(|col| {
+            let index = (col.column_index - 1) as usize;
+            match row.columns.get(index) {
+                Some(value) => format!("{value:?}"),
+                None => "NULL".to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("|")
 }


### PR DESCRIPTION
resolved: #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동기화 작업 중 중복된 행 처리가 개선되었습니다. MongoDB 및 PostgreSQL 데이터 삽입 시 동일 키의 중복 항목이 감지되면 가장 최신의 항목만 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->