### PR TITLE
[#172] pgoutput 파싱 버그 수정

### DIFF
--- a/src/adapter/postgres/pgoutput.rs
+++ b/src/adapter/postgres/pgoutput.rs
@@ -267,6 +267,51 @@ pub fn parse_pg_output(bytes: &[u8]) -> errors::Result<Option<PgOutput>> {
     }
 }
 
+fn skip_tuple(cursor: &mut std::io::Cursor<&[u8]>) -> errors::Result<()> {
+    let column_count = cursor.read_u16::<byteorder::BigEndian>().map_err(|e| {
+        errors::Errors::PgOutputParseError(format!(
+            "Failed to read column count while skipping tuple: {e}"
+        ))
+    })? as usize;
+
+    for _ in 0..column_count {
+        let column_type = cursor.read_u8().map_err(|e| {
+            errors::Errors::PgOutputParseError(format!(
+                "Failed to read column type while skipping tuple: {e}"
+            ))
+        })?;
+
+        match column_type {
+            b'n' | b'u' => {
+                // NULL or UNCHANGED - no data follows
+            }
+            b't' | b'b' => {
+                // Text or Binary - read and discard
+                let length = cursor.read_u32::<byteorder::BigEndian>().map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!(
+                        "Failed to read length while skipping tuple: {e}"
+                    ))
+                })? as usize;
+
+                let mut buffer = vec![0u8; length];
+                cursor.read_exact(&mut buffer).map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!(
+                        "Failed to skip bytes in tuple: {e}"
+                    ))
+                })?;
+            }
+            _ => {
+                return Err(errors::Errors::PgOutputParseError(format!(
+                    "Unknown column type while skipping tuple: 0x{:02x}",
+                    column_type
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Result<PgOutput> {
     let mut cursor = std::io::Cursor::new(&bytes[1..]); // Skip the first byte (message type)
 
@@ -300,13 +345,33 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
             })?;
 
             // Update: relation_id + ('K'|'O'|'N') + tuple_data
+            // If 'K' or 'O' (old tuple), skip it and read the following 'N' (new tuple)
             let tuple_type_byte = cursor.read_u8().map_err(|e| {
                 errors::Errors::PgOutputParseError(format!("Failed to read tuple type: {e}"))
             })?;
 
-            pg_output.tuple_type = Some(PgTupleType::try_from(tuple_type_byte).map_err(|e| {
+            let tuple_type = PgTupleType::try_from(tuple_type_byte).map_err(|e| {
                 errors::Errors::PgOutputParseError(format!("Invalid tuple type: {e}"))
-            })?);
+            })?;
+
+            if tuple_type == PgTupleType::Key || tuple_type == PgTupleType::Old {
+                // Skip old tuple data
+                skip_tuple(&mut cursor)?;
+
+                // Read 'N' marker for new tuple
+                let new_tuple_type_byte = cursor.read_u8().map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!(
+                        "Failed to read new tuple type after old tuple: {e}"
+                    ))
+                })?;
+
+                pg_output.tuple_type =
+                    Some(PgTupleType::try_from(new_tuple_type_byte).map_err(|e| {
+                        errors::Errors::PgOutputParseError(format!("Invalid new tuple type: {e}"))
+                    })?);
+            } else {
+                pg_output.tuple_type = Some(tuple_type);
+            }
         }
         MessageType::Delete => {
             // Read relation ID (4 bytes)

--- a/src/adapter/postgres/pgoutput.rs
+++ b/src/adapter/postgres/pgoutput.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 
 use byteorder::ReadBytesExt;
 use serde::{Deserialize, Serialize};
@@ -286,17 +286,16 @@ fn skip_tuple(cursor: &mut std::io::Cursor<&[u8]>) -> errors::Result<()> {
                 // NULL or UNCHANGED - no data follows
             }
             b't' | b'b' => {
-                // Text or Binary - read and discard
+                // Text or Binary - seek past without allocating
                 let length = cursor.read_u32::<byteorder::BigEndian>().map_err(|e| {
                     errors::Errors::PgOutputParseError(format!(
                         "Failed to read length while skipping tuple: {e}"
                     ))
-                })? as usize;
+                })? as i64;
 
-                let mut buffer = vec![0u8; length];
-                cursor.read_exact(&mut buffer).map_err(|e| {
+                cursor.seek(SeekFrom::Current(length)).map_err(|e| {
                     errors::Errors::PgOutputParseError(format!(
-                        "Failed to skip bytes in tuple: {e}"
+                        "Failed to seek while skipping tuple bytes: {e}"
                     ))
                 })?;
             }

--- a/src/adapter/postgres/pgoutput.rs
+++ b/src/adapter/postgres/pgoutput.rs
@@ -364,10 +364,15 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
                     ))
                 })?;
 
-                pg_output.tuple_type =
-                    Some(PgTupleType::try_from(new_tuple_type_byte).map_err(|e| {
-                        errors::Errors::PgOutputParseError(format!("Invalid new tuple type: {e}"))
-                    })?);
+                let new_tuple_type = PgTupleType::try_from(new_tuple_type_byte).map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!("Invalid new tuple type: {e}"))
+                })?;
+                if new_tuple_type != PgTupleType::New {
+                    return Err(errors::Errors::PgOutputParseError(format!(
+                        "Expected 'N' tuple after old tuple in UPDATE, got: 0x{new_tuple_type_byte:02x}"
+                    )));
+                }
+                pg_output.tuple_type = Some(new_tuple_type);
             } else {
                 pg_output.tuple_type = Some(tuple_type);
             }


### PR DESCRIPTION
resolved: #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PostgreSQL 업데이트 메시지 처리 로직의 정확성 향상 — 이전/키(old/key) 데이터 처리 시 불필요한 데이터 건너뛰기 개선으로 안정성 및 예외 처리 강화
  * 관련 메시지 파싱 신뢰성 개선으로 데이터 동기화 및 업데이트 반영의 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->