### PR TITLE
[#174] pgoutput 파싱시 unchange 값이 있을 경우 old tuple을 참조하게 변경

### DIFF
--- a/src/adapter/postgres/pgoutput.rs
+++ b/src/adapter/postgres/pgoutput.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 
 use byteorder::ReadBytesExt;
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,7 @@ pub struct PgOutput {
     pub relation_id: u32,
     pub tuple_type: Option<PgTupleType>,
     pub payload: Vec<PgOutputValue>,
+    pub old_values: Option<Vec<PgOutputValue>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -267,48 +268,75 @@ pub fn parse_pg_output(bytes: &[u8]) -> errors::Result<Option<PgOutput>> {
     }
 }
 
-fn skip_tuple(cursor: &mut std::io::Cursor<&[u8]>) -> errors::Result<()> {
+fn read_tuple(cursor: &mut std::io::Cursor<&[u8]>) -> errors::Result<Vec<PgOutputValue>> {
     let column_count = cursor.read_u16::<byteorder::BigEndian>().map_err(|e| {
         errors::Errors::PgOutputParseError(format!(
-            "Failed to read column count while skipping tuple: {e}"
+            "Failed to read column count while reading tuple: {e}"
         ))
     })? as usize;
+
+    let mut values = Vec::with_capacity(column_count);
 
     for _ in 0..column_count {
         let column_type = cursor.read_u8().map_err(|e| {
             errors::Errors::PgOutputParseError(format!(
-                "Failed to read column type while skipping tuple: {e}"
+                "Failed to read column type while reading tuple: {e}"
             ))
         })?;
 
         match column_type {
-            b'n' | b'u' => {
-                // NULL or UNCHANGED - no data follows
+            b'n' => {
+                values.push(PgOutputValue::Null);
             }
-            b't' | b'b' => {
-                // Text or Binary - seek past without allocating
+            b'u' => {
+                values.push(PgOutputValue::Unchanged);
+            }
+            b't' => {
                 let length = cursor.read_u32::<byteorder::BigEndian>().map_err(|e| {
                     errors::Errors::PgOutputParseError(format!(
-                        "Failed to read length while skipping tuple: {e}"
+                        "Failed to read length while reading tuple: {e}"
                     ))
-                })? as i64;
+                })? as usize;
 
-                cursor.seek(SeekFrom::Current(length)).map_err(|e| {
+                let mut buffer = vec![0u8; length];
+                cursor.read_exact(&mut buffer).map_err(|e| {
                     errors::Errors::PgOutputParseError(format!(
-                        "Failed to seek while skipping tuple bytes: {e}"
+                        "Failed to read text value in tuple: {e}"
                     ))
                 })?;
+
+                let text_value = String::from_utf8(buffer).map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!("Invalid UTF-8 in tuple: {e}"))
+                })?;
+
+                values.push(PgOutputValue::Text(text_value));
+            }
+            b'b' => {
+                let length = cursor.read_u32::<byteorder::BigEndian>().map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!(
+                        "Failed to read length while reading tuple: {e}"
+                    ))
+                })? as usize;
+
+                let mut buffer = vec![0u8; length];
+                cursor.read_exact(&mut buffer).map_err(|e| {
+                    errors::Errors::PgOutputParseError(format!(
+                        "Failed to read binary value in tuple: {e}"
+                    ))
+                })?;
+
+                values.push(PgOutputValue::Binary(buffer));
             }
             _ => {
                 return Err(errors::Errors::PgOutputParseError(format!(
-                    "Unknown column type while skipping tuple: 0x{:02x}",
+                    "Unknown column type while reading tuple: 0x{:02x}",
                     column_type
                 )));
             }
         }
     }
 
-    Ok(())
+    Ok(values)
 }
 
 fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Result<PgOutput> {
@@ -319,6 +347,7 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
         relation_id: 0,
         tuple_type: None,
         payload: Vec::new(),
+        old_values: None,
     };
 
     match message_type {
@@ -354,8 +383,8 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
             })?;
 
             if tuple_type == PgTupleType::Key || tuple_type == PgTupleType::Old {
-                // Skip old tuple data
-                skip_tuple(&mut cursor)?;
+                // Read old tuple to use as fallback for Unchanged columns
+                let old_values = read_tuple(&mut cursor)?;
 
                 // Read 'N' marker for new tuple
                 let new_tuple_type_byte = cursor.read_u8().map_err(|e| {
@@ -373,6 +402,7 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
                     )));
                 }
                 pg_output.tuple_type = Some(new_tuple_type);
+                pg_output.old_values = Some(old_values);
             } else {
                 pg_output.tuple_type = Some(tuple_type);
             }
@@ -480,6 +510,17 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
                     "Unknown column type: {} (0x{:02x})",
                     column_type as char, column_type
                 )));
+            }
+        }
+    }
+
+    // Fill Unchanged columns from old_values (TOAST fallback)
+    if let Some(old_values) = &pg_output.old_values {
+        for (i, value) in pg_output.payload.iter_mut().enumerate() {
+            if matches!(value, PgOutputValue::Unchanged) {
+                if let Some(old_value) = old_values.get(i) {
+                    *value = old_value.clone();
+                }
             }
         }
     }

--- a/src/adapter/postgres/pgoutput.rs
+++ b/src/adapter/postgres/pgoutput.rs
@@ -520,7 +520,32 @@ fn parse_pg_output_write(message_type: MessageType, bytes: &[u8]) -> errors::Res
             if matches!(value, PgOutputValue::Unchanged) {
                 if let Some(old_value) = old_values.get(i) {
                     *value = old_value.clone();
+                } else {
+                    log::warn!(
+                        "TOAST: Unchanged column at index {i} could not be resolved from old_values (relation_id={})",
+                        pg_output.relation_id
+                    );
+                    *value = PgOutputValue::Null;
                 }
+            }
+        }
+    } else {
+        let unresolved: Vec<usize> = pg_output
+            .payload
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| matches!(v, PgOutputValue::Unchanged))
+            .map(|(i, _)| i)
+            .collect();
+
+        if !unresolved.is_empty() {
+            log::warn!(
+                "TOAST: Unchanged columns at indexes {:?} could not be resolved — no old_values available (relation_id={}). Consider enabling REPLICA IDENTITY FULL. Falling back to NULL.",
+                unresolved,
+                pg_output.relation_id
+            );
+            for i in unresolved {
+                pg_output.payload[i] = PgOutputValue::Null;
             }
         }
     }


### PR DESCRIPTION
resolved: #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * UPDATE 처리 시 이전 행을 건너뛰지 않고 완전 파싱하여 열 값 정확성 향상.
  * 미해결된 미변경(Unchanged) 값이 있을 경우 누락된 값을 널로 대체하고 경고를 출력하도록 개선.

* **새로운 기능**
  * UPDATE 작업에서 이전 행 값(old values)을 추적하여 미변경 필드를 복구할 수 있게 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->