### PR TITLE
fix(postgres): 초기 동기화 시 COPY escape를 정상 복원하도록 수정

### DIFF
--- a/src/adapter/postgres.rs
+++ b/src/adapter/postgres.rs
@@ -359,6 +359,108 @@ impl IntoClickhouseRow for PostgresCopyRow {
 }
 
 impl PostgresConnection {
+    fn finalize_copy_field(current_word: &mut String) -> PgOutputValue {
+        if current_word == "\\N" {
+            current_word.clear();
+            return PgOutputValue::Null;
+        }
+
+        let raw = std::mem::take(current_word);
+
+        PgOutputValue::Text(Self::decode_copy_text_field(&raw))
+    }
+
+    fn decode_copy_text_field(input: &str) -> String {
+        let mut decoded = String::with_capacity(input.len());
+        let chars: Vec<char> = input.chars().collect();
+        let mut index = 0;
+
+        while index < chars.len() {
+            if chars[index] != '\\' {
+                decoded.push(chars[index]);
+                index += 1;
+                continue;
+            }
+
+            index += 1;
+
+            if index >= chars.len() {
+                decoded.push('\\');
+                break;
+            }
+
+            match chars[index] {
+                'b' => {
+                    decoded.push('\u{0008}');
+                    index += 1;
+                }
+                'f' => {
+                    decoded.push('\u{000C}');
+                    index += 1;
+                }
+                'n' => {
+                    decoded.push('\n');
+                    index += 1;
+                }
+                'r' => {
+                    decoded.push('\r');
+                    index += 1;
+                }
+                't' => {
+                    decoded.push('\t');
+                    index += 1;
+                }
+                'v' => {
+                    decoded.push('\u{000B}');
+                    index += 1;
+                }
+                '\\' => {
+                    decoded.push('\\');
+                    index += 1;
+                }
+                'x' => {
+                    if index + 2 < chars.len() {
+                        let hex: String = chars[index + 1..=index + 2].iter().collect();
+
+                        if let Ok(value) = u8::from_str_radix(&hex, 16) {
+                            decoded.push(value as char);
+                            index += 3;
+                            continue;
+                        }
+                    }
+
+                    decoded.push('x');
+                    index += 1;
+                }
+                '0'..='7' => {
+                    let start = index;
+                    let end = usize::min(index + 3, chars.len());
+                    let octal_end = chars[start..end]
+                        .iter()
+                        .take_while(|c| matches!(c, '0'..='7'))
+                        .count()
+                        + start;
+
+                    let octal: String = chars[start..octal_end].iter().collect();
+
+                    if let Ok(value) = u8::from_str_radix(&octal, 8) {
+                        decoded.push(value as char);
+                        index = octal_end;
+                    } else {
+                        decoded.push(chars[index]);
+                        index += 1;
+                    }
+                }
+                other => {
+                    decoded.push(other);
+                    index += 1;
+                }
+            }
+        }
+
+        decoded
+    }
+
     pub async fn find_publication_by_name(
         &self,
         publication_name: &str,
@@ -719,31 +821,34 @@ impl PostgresConnection {
 
                 // 바이트를 UTF-8 문자열로 변환하여 바로 파싱
                 let text = unsafe { std::str::from_utf8_unchecked(&bytes) };
+                let mut previous_was_escape = false;
 
                 for c in text.chars() {
+                    if previous_was_escape {
+                        current_word.push(c);
+                        previous_was_escape = false;
+                        continue;
+                    }
+
+                    if c == '\\' {
+                        current_word.push(c);
+                        previous_was_escape = true;
+                        continue;
+                    }
+
                     // column separator
                     if c == '\t' {
-                        if current_word == "\\N" {
-                            current_row.columns.push(PgOutputValue::Null);
-                            current_word.clear();
-                        } else {
-                            current_row
-                                .columns
-                                .push(PgOutputValue::Text(std::mem::take(&mut current_word)));
-                        }
+                        current_row
+                            .columns
+                            .push(Self::finalize_copy_field(&mut current_word));
                         continue;
                     }
 
                     // row separator
                     if c == '\n' {
-                        if current_word == "\\N" {
-                            current_row.columns.push(PgOutputValue::Null);
-                            current_word.clear();
-                        } else if !current_word.is_empty() {
-                            current_row
-                                .columns
-                                .push(PgOutputValue::Text(std::mem::take(&mut current_word)));
-                        }
+                        current_row
+                            .columns
+                            .push(Self::finalize_copy_field(&mut current_word));
 
                         rows.push(std::mem::take(&mut current_row));
                         continue;
@@ -765,5 +870,46 @@ impl PostgresConnection {
         });
 
         Ok(receiver)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PostgresConnection;
+    use crate::adapter::postgres::pgoutput::PgOutputValue;
+
+    fn decode_copy_text_field_before_fix(input: &str) -> String {
+        input.to_string()
+    }
+
+    #[test]
+    fn decode_copy_text_field_before_and_after_json_escape_sequences() {
+        let raw = r#"{"style_summary":"типа \\\"треугольник\\\""}"#;
+        let before = decode_copy_text_field_before_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, r#"{"style_summary":"типа \\\"треугольник\\\""}"#);
+        assert_eq!(after, r#"{"style_summary":"типа \"треугольник\""}"#);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_before_and_after_control_characters() {
+        let raw = r#"line1\nline2\tvalue\\path"#;
+        let before = decode_copy_text_field_before_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, r#"line1\nline2\tvalue\\path"#);
+        assert_eq!(after, "line1\nline2\tvalue\\path");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_keeps_null_sentinel_handling_separate() {
+        let mut raw = r#"\N"#.to_string();
+        let finalized = PostgresConnection::finalize_copy_field(&mut raw);
+
+        assert!(matches!(finalized, PgOutputValue::Null));
+        assert!(raw.is_empty());
     }
 }

--- a/src/adapter/postgres.rs
+++ b/src/adapter/postgres.rs
@@ -371,13 +371,15 @@ impl PostgresConnection {
     }
 
     fn decode_copy_text_field(input: &str) -> String {
-        let mut decoded = String::with_capacity(input.len());
+        let mut decoded = Vec::with_capacity(input.len());
         let chars: Vec<char> = input.chars().collect();
         let mut index = 0;
 
         while index < chars.len() {
             if chars[index] != '\\' {
-                decoded.push(chars[index]);
+                let mut buffer = [0u8; 4];
+                let encoded = chars[index].encode_utf8(&mut buffer);
+                decoded.extend_from_slice(encoded.as_bytes());
                 index += 1;
                 continue;
             }
@@ -385,37 +387,37 @@ impl PostgresConnection {
             index += 1;
 
             if index >= chars.len() {
-                decoded.push('\\');
+                decoded.push(b'\\');
                 break;
             }
 
             match chars[index] {
                 'b' => {
-                    decoded.push('\u{0008}');
+                    decoded.push(0x08);
                     index += 1;
                 }
                 'f' => {
-                    decoded.push('\u{000C}');
+                    decoded.push(0x0C);
                     index += 1;
                 }
                 'n' => {
-                    decoded.push('\n');
+                    decoded.push(b'\n');
                     index += 1;
                 }
                 'r' => {
-                    decoded.push('\r');
+                    decoded.push(b'\r');
                     index += 1;
                 }
                 't' => {
-                    decoded.push('\t');
+                    decoded.push(b'\t');
                     index += 1;
                 }
                 'v' => {
-                    decoded.push('\u{000B}');
+                    decoded.push(0x0B);
                     index += 1;
                 }
                 '\\' => {
-                    decoded.push('\\');
+                    decoded.push(b'\\');
                     index += 1;
                 }
                 'x' => {
@@ -430,13 +432,13 @@ impl PostgresConnection {
                     if hex_end > index + 1 {
                         let hex: String = chars[index + 1..hex_end].iter().collect();
                         if let Ok(value) = u8::from_str_radix(&hex, 16) {
-                            decoded.push(value as char);
+                            decoded.push(value);
                             index = hex_end;
                             continue;
                         }
                     }
 
-                    decoded.push('x');
+                    decoded.push(b'x');
                     index += 1;
                 }
                 '0'..='7' => {
@@ -451,21 +453,26 @@ impl PostgresConnection {
                     let octal: String = chars[start..octal_end].iter().collect();
 
                     if let Ok(value) = u8::from_str_radix(&octal, 8) {
-                        decoded.push(value as char);
+                        decoded.push(value);
                         index = octal_end;
                     } else {
-                        decoded.push(chars[index]);
+                        let mut buffer = [0u8; 4];
+                        let encoded = chars[index].encode_utf8(&mut buffer);
+                        decoded.extend_from_slice(encoded.as_bytes());
                         index += 1;
                     }
                 }
                 other => {
-                    decoded.push(other);
+                    let mut buffer = [0u8; 4];
+                    let encoded = other.encode_utf8(&mut buffer);
+                    decoded.extend_from_slice(encoded.as_bytes());
                     index += 1;
                 }
             }
         }
 
-        decoded
+        String::from_utf8(decoded)
+            .unwrap_or_else(|error| String::from_utf8_lossy(&error.into_bytes()).into_owned())
     }
 
     #[cfg(test)]
@@ -934,6 +941,76 @@ mod tests {
         input.to_string()
     }
 
+    fn decode_copy_text_field_before_utf8_byte_fix(input: &str) -> String {
+        let mut decoded = String::with_capacity(input.len());
+        let chars: Vec<char> = input.chars().collect();
+        let mut index = 0;
+
+        while index < chars.len() {
+            if chars[index] != '\\' {
+                decoded.push(chars[index]);
+                index += 1;
+                continue;
+            }
+
+            index += 1;
+
+            if index >= chars.len() {
+                decoded.push('\\');
+                break;
+            }
+
+            match chars[index] {
+                'x' => {
+                    let end = usize::min(index + 3, chars.len());
+                    let hex_end = chars[index + 1..end]
+                        .iter()
+                        .take_while(|c| c.is_ascii_hexdigit())
+                        .count()
+                        + index
+                        + 1;
+
+                    if hex_end > index + 1 {
+                        let hex: String = chars[index + 1..hex_end].iter().collect();
+                        if let Ok(value) = u8::from_str_radix(&hex, 16) {
+                            decoded.push(value as char);
+                            index = hex_end;
+                            continue;
+                        }
+                    }
+
+                    decoded.push('x');
+                    index += 1;
+                }
+                '0'..='7' => {
+                    let start = index;
+                    let end = usize::min(index + 3, chars.len());
+                    let octal_end = chars[start..end]
+                        .iter()
+                        .take_while(|c| matches!(c, '0'..='7'))
+                        .count()
+                        + start;
+
+                    let octal: String = chars[start..octal_end].iter().collect();
+
+                    if let Ok(value) = u8::from_str_radix(&octal, 8) {
+                        decoded.push(value as char);
+                        index = octal_end;
+                    } else {
+                        decoded.push(chars[index]);
+                        index += 1;
+                    }
+                }
+                other => {
+                    decoded.push(other);
+                    index += 1;
+                }
+            }
+        }
+
+        decoded
+    }
+
     #[test]
     fn decode_copy_text_field_before_and_after_json_escape_sequences() {
         let raw = r#"{"style_summary":"типа \\\"треугольник\\\""}"#;
@@ -975,6 +1052,28 @@ mod tests {
 
         assert_eq!(before, r#"prefix\x41suffix"#);
         assert_eq!(after, "prefixAsuffix");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_restores_utf8_multibyte_hex_escape() {
+        let raw = r#"\xC3\xA9"#;
+        let before = decode_copy_text_field_before_utf8_byte_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, "Ã©");
+        assert_eq!(after, "é");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_restores_utf8_multibyte_octal_escape() {
+        let raw = r#"\303\251"#;
+        let before = decode_copy_text_field_before_utf8_byte_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, "Ã©");
+        assert_eq!(after, "é");
         assert_ne!(before, after);
     }
 

--- a/src/adapter/postgres.rs
+++ b/src/adapter/postgres.rs
@@ -468,6 +468,51 @@ impl PostgresConnection {
         decoded
     }
 
+    #[cfg(test)]
+    fn parse_copy_chunks(chunks: &[&str]) -> Vec<PostgresCopyRow> {
+        let mut current_row = PostgresCopyRow {
+            columns: Vec::new(),
+        };
+        let mut current_word = String::new();
+        let mut previous_was_escape = false;
+        let mut rows = Vec::new();
+
+        for text in chunks {
+            for c in text.chars() {
+                if previous_was_escape {
+                    current_word.push(c);
+                    previous_was_escape = false;
+                    continue;
+                }
+
+                if c == '\\' {
+                    current_word.push(c);
+                    previous_was_escape = true;
+                    continue;
+                }
+
+                if c == '\t' {
+                    current_row
+                        .columns
+                        .push(Self::finalize_copy_field(&mut current_word));
+                    continue;
+                }
+
+                if c == '\n' {
+                    current_row
+                        .columns
+                        .push(Self::finalize_copy_field(&mut current_word));
+                    rows.push(std::mem::take(&mut current_row));
+                    continue;
+                }
+
+                current_word.push(c);
+            }
+        }
+
+        rows
+    }
+
     pub async fn find_publication_by_name(
         &self,
         publication_name: &str,
@@ -813,6 +858,7 @@ impl PostgresConnection {
                 columns: Vec::new(),
             };
             let mut current_word = String::new();
+            let mut previous_was_escape = false;
 
             let mut stream: std::pin::Pin<Box<tokio_postgres::CopyOutStream>> = Box::pin(copy_sink);
             while let Some(chunk) = stream.next().await {
@@ -828,7 +874,6 @@ impl PostgresConnection {
 
                 // 바이트를 UTF-8 문자열로 변환하여 바로 파싱
                 let text = unsafe { std::str::from_utf8_unchecked(&bytes) };
-                let mut previous_was_escape = false;
 
                 for c in text.chars() {
                     if previous_was_escape {
@@ -940,5 +985,25 @@ mod tests {
 
         assert!(matches!(finalized, PgOutputValue::Null));
         assert!(raw.is_empty());
+    }
+
+    #[test]
+    fn parse_copy_chunks_preserves_escape_state_across_chunk_boundaries() {
+        let rows = PostgresConnection::parse_copy_chunks(&[
+            r#"prefix\"#,
+            r#""suffix	1
+"#,
+        ]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].columns.len(), 2);
+        assert!(matches!(
+            &rows[0].columns[0],
+            PgOutputValue::Text(value) if value == "prefix\"suffix"
+        ));
+        assert!(matches!(
+            &rows[0].columns[1],
+            PgOutputValue::Text(value) if value == "1"
+        ));
     }
 }

--- a/src/adapter/postgres.rs
+++ b/src/adapter/postgres.rs
@@ -419,12 +419,19 @@ impl PostgresConnection {
                     index += 1;
                 }
                 'x' => {
-                    if index + 2 < chars.len() {
-                        let hex: String = chars[index + 1..=index + 2].iter().collect();
+                    let end = usize::min(index + 3, chars.len());
+                    let hex_end = chars[index + 1..end]
+                        .iter()
+                        .take_while(|c| c.is_ascii_hexdigit())
+                        .count()
+                        + index
+                        + 1;
 
+                    if hex_end > index + 1 {
+                        let hex: String = chars[index + 1..hex_end].iter().collect();
                         if let Ok(value) = u8::from_str_radix(&hex, 16) {
                             decoded.push(value as char);
-                            index += 3;
+                            index = hex_end;
                             continue;
                         }
                     }
@@ -901,6 +908,28 @@ mod tests {
 
         assert_eq!(before, r#"line1\nline2\tvalue\\path"#);
         assert_eq!(after, "line1\nline2\tvalue\\path");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_before_and_after_single_digit_hex_escape() {
+        let raw = r#"prefix\xAsuffix"#;
+        let before = decode_copy_text_field_before_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, r#"prefix\xAsuffix"#);
+        assert_eq!(after, "prefix\nsuffix");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decode_copy_text_field_before_and_after_double_digit_hex_escape() {
+        let raw = r#"prefix\x41suffix"#;
+        let before = decode_copy_text_field_before_fix(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw);
+
+        assert_eq!(before, r#"prefix\x41suffix"#);
+        assert_eq!(after, "prefixAsuffix");
         assert_ne!(before, after);
     }
 

--- a/src/adapter/postgres.rs
+++ b/src/adapter/postgres.rs
@@ -359,8 +359,8 @@ impl IntoClickhouseRow for PostgresCopyRow {
 }
 
 impl PostgresConnection {
-    fn finalize_copy_field(current_word: &mut String) -> PgOutputValue {
-        if current_word == "\\N" {
+    fn finalize_copy_field(current_word: &mut Vec<u8>) -> PgOutputValue {
+        if current_word.as_slice() == b"\\N" {
             current_word.clear();
             return PgOutputValue::Null;
         }
@@ -370,59 +370,56 @@ impl PostgresConnection {
         PgOutputValue::Text(Self::decode_copy_text_field(&raw))
     }
 
-    fn decode_copy_text_field(input: &str) -> String {
+    fn decode_copy_text_field(input: &[u8]) -> String {
         let mut decoded = Vec::with_capacity(input.len());
-        let chars: Vec<char> = input.chars().collect();
         let mut index = 0;
 
-        while index < chars.len() {
-            if chars[index] != '\\' {
-                let mut buffer = [0u8; 4];
-                let encoded = chars[index].encode_utf8(&mut buffer);
-                decoded.extend_from_slice(encoded.as_bytes());
+        while index < input.len() {
+            if input[index] != b'\\' {
+                decoded.push(input[index]);
                 index += 1;
                 continue;
             }
 
             index += 1;
 
-            if index >= chars.len() {
+            if index >= input.len() {
                 decoded.push(b'\\');
                 break;
             }
 
-            match chars[index] {
-                'b' => {
+            match input[index] {
+                b'b' => {
                     decoded.push(0x08);
                     index += 1;
                 }
-                'f' => {
+                b'f' => {
                     decoded.push(0x0C);
                     index += 1;
                 }
-                'n' => {
+                b'n' => {
                     decoded.push(b'\n');
                     index += 1;
                 }
-                'r' => {
+                b'r' => {
                     decoded.push(b'\r');
                     index += 1;
                 }
-                't' => {
+                b't' => {
                     decoded.push(b'\t');
                     index += 1;
                 }
-                'v' => {
+                b'v' => {
                     decoded.push(0x0B);
                     index += 1;
                 }
-                '\\' => {
+                b'\\' => {
                     decoded.push(b'\\');
                     index += 1;
                 }
-                'x' => {
-                    let end = usize::min(index + 3, chars.len());
-                    let hex_end = chars[index + 1..end]
+                b'x' => {
+                    let end = usize::min(index + 3, input.len());
+                    let hex_end = input[index + 1..end]
                         .iter()
                         .take_while(|c| c.is_ascii_hexdigit())
                         .count()
@@ -430,42 +427,40 @@ impl PostgresConnection {
                         + 1;
 
                     if hex_end > index + 1 {
-                        let hex: String = chars[index + 1..hex_end].iter().collect();
-                        if let Ok(value) = u8::from_str_radix(&hex, 16) {
-                            decoded.push(value);
-                            index = hex_end;
-                            continue;
+                        if let Ok(hex) = std::str::from_utf8(&input[index + 1..hex_end]) {
+                            if let Ok(value) = u8::from_str_radix(hex, 16) {
+                                decoded.push(value);
+                                index = hex_end;
+                                continue;
+                            }
                         }
                     }
 
                     decoded.push(b'x');
                     index += 1;
                 }
-                '0'..='7' => {
+                b'0'..=b'7' => {
                     let start = index;
-                    let end = usize::min(index + 3, chars.len());
-                    let octal_end = chars[start..end]
+                    let end = usize::min(index + 3, input.len());
+                    let octal_end = input[start..end]
                         .iter()
-                        .take_while(|c| matches!(c, '0'..='7'))
+                        .take_while(|c| matches!(c, b'0'..=b'7'))
                         .count()
                         + start;
 
-                    let octal: String = chars[start..octal_end].iter().collect();
-
-                    if let Ok(value) = u8::from_str_radix(&octal, 8) {
-                        decoded.push(value);
-                        index = octal_end;
-                    } else {
-                        let mut buffer = [0u8; 4];
-                        let encoded = chars[index].encode_utf8(&mut buffer);
-                        decoded.extend_from_slice(encoded.as_bytes());
-                        index += 1;
+                    if let Ok(octal) = std::str::from_utf8(&input[start..octal_end]) {
+                        if let Ok(value) = u8::from_str_radix(octal, 8) {
+                            decoded.push(value);
+                            index = octal_end;
+                            continue;
+                        }
                     }
+
+                    decoded.push(input[index]);
+                    index += 1;
                 }
                 other => {
-                    let mut buffer = [0u8; 4];
-                    let encoded = other.encode_utf8(&mut buffer);
-                    decoded.extend_from_slice(encoded.as_bytes());
+                    decoded.push(other);
                     index += 1;
                 }
             }
@@ -475,49 +470,64 @@ impl PostgresConnection {
             .unwrap_or_else(|error| String::from_utf8_lossy(&error.into_bytes()).into_owned())
     }
 
-    #[cfg(test)]
-    fn parse_copy_chunks(chunks: &[&str]) -> Vec<PostgresCopyRow> {
-        let mut current_row = PostgresCopyRow {
-            columns: Vec::new(),
-        };
-        let mut current_word = String::new();
-        let mut previous_was_escape = false;
+    fn parse_copy_bytes_chunks_with_state(
+        chunks: &[&[u8]],
+        current_row: &mut PostgresCopyRow,
+        current_word: &mut Vec<u8>,
+        previous_was_escape: &mut bool,
+    ) -> Vec<PostgresCopyRow> {
         let mut rows = Vec::new();
 
-        for text in chunks {
-            for c in text.chars() {
-                if previous_was_escape {
-                    current_word.push(c);
-                    previous_was_escape = false;
+        for chunk in chunks {
+            for &byte in *chunk {
+                if *previous_was_escape {
+                    current_word.push(byte);
+                    *previous_was_escape = false;
                     continue;
                 }
 
-                if c == '\\' {
-                    current_word.push(c);
-                    previous_was_escape = true;
+                if byte == b'\\' {
+                    current_word.push(byte);
+                    *previous_was_escape = true;
                     continue;
                 }
 
-                if c == '\t' {
+                if byte == b'\t' {
                     current_row
                         .columns
-                        .push(Self::finalize_copy_field(&mut current_word));
+                        .push(Self::finalize_copy_field(current_word));
                     continue;
                 }
 
-                if c == '\n' {
+                if byte == b'\n' {
                     current_row
                         .columns
-                        .push(Self::finalize_copy_field(&mut current_word));
-                    rows.push(std::mem::take(&mut current_row));
+                        .push(Self::finalize_copy_field(current_word));
+                    rows.push(std::mem::take(current_row));
                     continue;
                 }
 
-                current_word.push(c);
+                current_word.push(byte);
             }
         }
 
         rows
+    }
+
+    #[cfg(test)]
+    fn parse_copy_chunks(chunks: &[&[u8]]) -> Vec<PostgresCopyRow> {
+        let mut current_row = PostgresCopyRow {
+            columns: Vec::new(),
+        };
+        let mut current_word = Vec::new();
+        let mut previous_was_escape = false;
+
+        Self::parse_copy_bytes_chunks_with_state(
+            chunks,
+            &mut current_row,
+            &mut current_word,
+            &mut previous_was_escape,
+        )
     }
 
     pub async fn find_publication_by_name(
@@ -864,13 +874,11 @@ impl PostgresConnection {
             let mut current_row = PostgresCopyRow {
                 columns: Vec::new(),
             };
-            let mut current_word = String::new();
+            let mut current_word = Vec::new();
             let mut previous_was_escape = false;
 
             let mut stream: std::pin::Pin<Box<tokio_postgres::CopyOutStream>> = Box::pin(copy_sink);
             while let Some(chunk) = stream.next().await {
-                let mut rows = Vec::new();
-
                 let bytes = match chunk {
                     Ok(bytes) => bytes,
                     Err(error) => {
@@ -879,42 +887,12 @@ impl PostgresConnection {
                     }
                 };
 
-                // 바이트를 UTF-8 문자열로 변환하여 바로 파싱
-                let text = unsafe { std::str::from_utf8_unchecked(&bytes) };
-
-                for c in text.chars() {
-                    if previous_was_escape {
-                        current_word.push(c);
-                        previous_was_escape = false;
-                        continue;
-                    }
-
-                    if c == '\\' {
-                        current_word.push(c);
-                        previous_was_escape = true;
-                        continue;
-                    }
-
-                    // column separator
-                    if c == '\t' {
-                        current_row
-                            .columns
-                            .push(Self::finalize_copy_field(&mut current_word));
-                        continue;
-                    }
-
-                    // row separator
-                    if c == '\n' {
-                        current_row
-                            .columns
-                            .push(Self::finalize_copy_field(&mut current_word));
-
-                        rows.push(std::mem::take(&mut current_row));
-                        continue;
-                    }
-
-                    current_word.push(c);
-                }
+                let rows = Self::parse_copy_bytes_chunks_with_state(
+                    &[bytes.as_ref()],
+                    &mut current_row,
+                    &mut current_word,
+                    &mut previous_was_escape,
+                );
 
                 sender
                     .send(rows)
@@ -1015,7 +993,7 @@ mod tests {
     fn decode_copy_text_field_before_and_after_json_escape_sequences() {
         let raw = r#"{"style_summary":"типа \\\"треугольник\\\""}"#;
         let before = decode_copy_text_field_before_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, r#"{"style_summary":"типа \\\"треугольник\\\""}"#);
         assert_eq!(after, r#"{"style_summary":"типа \"треугольник\""}"#);
@@ -1026,7 +1004,7 @@ mod tests {
     fn decode_copy_text_field_before_and_after_control_characters() {
         let raw = r#"line1\nline2\tvalue\\path"#;
         let before = decode_copy_text_field_before_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, r#"line1\nline2\tvalue\\path"#);
         assert_eq!(after, "line1\nline2\tvalue\\path");
@@ -1037,7 +1015,7 @@ mod tests {
     fn decode_copy_text_field_before_and_after_single_digit_hex_escape() {
         let raw = r#"prefix\xAsuffix"#;
         let before = decode_copy_text_field_before_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, r#"prefix\xAsuffix"#);
         assert_eq!(after, "prefix\nsuffix");
@@ -1048,7 +1026,7 @@ mod tests {
     fn decode_copy_text_field_before_and_after_double_digit_hex_escape() {
         let raw = r#"prefix\x41suffix"#;
         let before = decode_copy_text_field_before_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, r#"prefix\x41suffix"#);
         assert_eq!(after, "prefixAsuffix");
@@ -1059,7 +1037,7 @@ mod tests {
     fn decode_copy_text_field_restores_utf8_multibyte_hex_escape() {
         let raw = r#"\xC3\xA9"#;
         let before = decode_copy_text_field_before_utf8_byte_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, "Ã©");
         assert_eq!(after, "é");
@@ -1070,7 +1048,7 @@ mod tests {
     fn decode_copy_text_field_restores_utf8_multibyte_octal_escape() {
         let raw = r#"\303\251"#;
         let before = decode_copy_text_field_before_utf8_byte_fix(raw);
-        let after = PostgresConnection::decode_copy_text_field(raw);
+        let after = PostgresConnection::decode_copy_text_field(raw.as_bytes());
 
         assert_eq!(before, "Ã©");
         assert_eq!(after, "é");
@@ -1079,7 +1057,7 @@ mod tests {
 
     #[test]
     fn decode_copy_text_field_keeps_null_sentinel_handling_separate() {
-        let mut raw = r#"\N"#.to_string();
+        let mut raw = r#"\N"#.as_bytes().to_vec();
         let finalized = PostgresConnection::finalize_copy_field(&mut raw);
 
         assert!(matches!(finalized, PgOutputValue::Null));
@@ -1088,17 +1066,29 @@ mod tests {
 
     #[test]
     fn parse_copy_chunks_preserves_escape_state_across_chunk_boundaries() {
-        let rows = PostgresConnection::parse_copy_chunks(&[
-            r#"prefix\"#,
-            r#""suffix	1
-"#,
-        ]);
+        let rows = PostgresConnection::parse_copy_chunks(&[br#"prefix\"#, b"\"suffix\t1\n"]);
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].columns.len(), 2);
         assert!(matches!(
             &rows[0].columns[0],
             PgOutputValue::Text(value) if value == "prefix\"suffix"
+        ));
+        assert!(matches!(
+            &rows[0].columns[1],
+            PgOutputValue::Text(value) if value == "1"
+        ));
+    }
+
+    #[test]
+    fn parse_copy_chunks_preserves_utf8_across_chunk_boundaries() {
+        let rows = PostgresConnection::parse_copy_chunks(&[b"caf\xC3", b"\xA9\t1\n"]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].columns.len(), 2);
+        assert!(matches!(
+            &rows[0].columns[0],
+            PgOutputValue::Text(value) if value == "café"
         ));
         assert!(matches!(
             &rows[0].columns[1],

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,11 +40,9 @@ pub mod run {
                     );
                     Ok(config)
                 }
-                Err(error) => {
-                    Err(errors::Errors::ConfigReadError(format!(
-                        "Failed to parse configuration file: {error}"
-                    )))
-                }
+                Err(error) => Err(errors::Errors::ConfigReadError(format!(
+                    "Failed to parse configuration file: {error}"
+                ))),
             }
         }
     }

--- a/src/pipes/mongodb.rs
+++ b/src/pipes/mongodb.rs
@@ -238,7 +238,9 @@ impl IPipe for MongoDBPipe {
 
             logger.clean();
 
-            log::info!("Copy completed for collection {mongodb_collection_name} ({processed_rows} rows)");
+            log::info!(
+                "Copy completed for collection {mongodb_collection_name} ({processed_rows} rows)"
+            );
         }
     }
 


### PR DESCRIPTION
resolved: #176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PostgreSQL COPY 처리에서 이스케이프 시퀀스 디코딩 개선 및 `\N` 널 필드 처리 정확도 향상
  * 이스케이프된 구분자(예: 탭/개행)를 올바르게 해석하여 COPY 스트림 파싱 안정성 강화

* **리팩터링**
  * 구성 파일 읽기 시 오류 처리 로직 간소화

* **스타일**
  * MongoDB 관련 로그 호출 서식 정리

* **테스트**
  * COPY 필드 디코딩, 널 처리 및 청크 경계 파싱 연속성 유닛 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->